### PR TITLE
[PR] Fixing mprotect and VirtualProtect usages, typos and english spelling

### DIFF
--- a/Linux/_Detector.asm
+++ b/Linux/_Detector.asm
@@ -6,7 +6,7 @@ GLOBAL _ThreadWhichModify
 section .text ; makes this executable
 	
 	_ThreadWhichModify:
-		mov byte[rel Sync], 1				; Synchronize the thread, but to early in order to exploit the FIFO property of the processor cache.
+		mov byte[rel Sync], 1				; Synchronize the thread, but too early in order to exploit the FIFO property of the processor cache.
 		mov byte[rel codeToModify + 1], 1	; Transform 'mov eax, 0' into 'mov eax, 1'.
 		ret
 

--- a/Windows/Detector/Main.c
+++ b/Windows/Detector/Main.c
@@ -11,7 +11,6 @@ extern void _ThreadWhichModify();
 
 #include <Windows.h>
 #include <stdio.h>
-#define NB_TEST 50
 BOOLEAN sync = FALSE;
 
 

--- a/Windows/Detector/Main.c
+++ b/Windows/Detector/Main.c
@@ -24,7 +24,7 @@ int main(int argc, char** argv) {
 	GetSystemInfo(&si);
 
 	//Change the page right to allow both execution and writing.
-	if (VirtualProtect(ModifiedThread, si.dwPageSize, PAGE_EXECUTE_READWRITE, &oldProtect) == 0) {
+	if (VirtualProtect(ModifiedThread, si.dwPageSize - 0xF, PAGE_EXECUTE_READWRITE, &oldProtect) == 0) {
 		return EXIT_FAILURE;
 	}
 
@@ -39,7 +39,7 @@ int main(int argc, char** argv) {
 	printf("%d\n",ModifiedThread());
 
 	//Restore the right of the page.
-	VirtualProtect(ModifiedThread, si.dwPageSize, oldProtect, &oldProtect);
+	VirtualProtect(ModifiedThread, si.dwPageSize - 0xF, oldProtect, &oldProtect);
 	WaitForSingleObject(ModifiedThread, INFINITE);
 
 	return EXIT_SUCCESS;

--- a/Windows/Detector/Main.c
+++ b/Windows/Detector/Main.c
@@ -11,33 +11,36 @@ extern void _ThreadWhichModify();
 
 #include <Windows.h>
 #include <stdio.h>
-
+#define NB_TEST 50
 BOOLEAN sync = FALSE;
 
 
 
+int main(int argc, char** argv) {
 
-int main() {
 	HANDLE hThread;
 	DWORD oldProtect;
+	SYSTEM_INFO si;
+	GetSystemInfo(&si);
 
 	//Change the page right to allow both execution and writing.
-	if (VirtualProtect(ModifiedThread, 100, PAGE_EXECUTE_READWRITE, &oldProtect) == 0) {
-		return -1;
+	if (VirtualProtect(ModifiedThread, si.dwPageSize, PAGE_EXECUTE_READWRITE, &oldProtect) == 0) {
+		return EXIT_FAILURE;
 	}
 
 	//Create a new thread to which will modify the code to execute.
 	hThread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)ThreadWhichModify, NULL, 0, NULL);
 	if (hThread == NULL) {
-		return -1;
+		return EXIT_FAILURE;
 	}
 
-	
+
 	//Execute the function that is modified and display its result.
-	printf("%d\n", ModifiedThread());
+	printf("%d\n",ModifiedThread());
 
 	//Restore the right of the page.
-	VirtualProtect(ModifiedThread, 100, oldProtect, &oldProtect);
+	VirtualProtect(ModifiedThread, si.dwPageSize, oldProtect, &oldProtect);
+	WaitForSingleObject(ModifiedThread, INFINITE);
 
-	return 0;
+	return EXIT_SUCCESS;
 }

--- a/Windows/Detector/_Detector.asm
+++ b/Windows/Detector/_Detector.asm
@@ -6,7 +6,7 @@ GLOBAL _ThreadWhichModify
 section .text ; makes this executable
 	
 	_ThreadWhichModify:
-		mov byte[rel Sync], 1				; Synchronize the thread, but to early in order to exploit the FIFO property of the processor cache.
+		mov byte[rel Sync], 1				; Synchronize the thread, but too early in order to exploit the FIFO property of the processor cache.
 		mov byte[rel codeToModify + 1], 1	; Transform 'mov eax, 0' into 'mov eax, 1'.
 		ret
 


### PR DESCRIPTION
This PR should fix a possible crash on Linux due to trying to modify protections of multiple pages the program may not have permission to change. 

According to their man pages, `mprotect` and `VirtualProtect` will modify permissions of all page in the given range [addr:addr+len]. Old len was giving arbitrary size, which (at least on linux) might create an error while trying to modify permissions of multiple pages we do not have sufficient permissions on. The correct way of modify those permissions would be to get the address of the end of `ModifiedThread`'s function using a trick such as described here : https://stackoverflow.com/a/11088648

Also changed some typos according to C standards and some english spellings.